### PR TITLE
Add Support for MoistenLand Water Timer

### DIFF
--- a/custom_components/tuya_local/devices/Moistenland_WaterTimer.yaml
+++ b/custom_components/tuya_local/devices/Moistenland_WaterTimer.yaml
@@ -1,0 +1,89 @@
+name: Moistenland Irrigation
+products:
+  - id: 8t5hebn0
+    name: MoistenLand Timer
+primary_entity:
+  entity: switch
+  dps:
+    - id: 1
+      name: switch
+      type: boolean
+secondary_entities:
+  - entity: sensor
+    name: Fault reporting
+    category: diagnostic
+    dps:
+      - id: 4
+        type: integer
+        name: sensor
+  - entity: sensor
+    name: Battery
+    class: battery
+    category: diagnostic
+    dps:
+      - id: 7
+        type: integer
+        name: sensor
+        unit: "%"
+  - entity: sensor
+    name: Battery Status
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 8
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "low"
+            value: "Replace Battery"
+          - dps_val: "middle"
+            value: "Battery Ok"
+          - dps_val: "high"
+            value: "Fully Charged"
+  - entity: select
+    name: Weather delay
+    icon: "mdi:weather-cloudy-clock"
+    category: config
+    dps:
+      - id: 10
+        type: string
+        name: option
+        mapping:
+          - dps_val: "cancel"
+            value: "Off"
+          - dps_val: "24h"
+            value: "1 day"
+          - dps_val: "48h"
+            value: "2 days"
+          - dps_val: "72h"
+            value: "3 days"
+  - entity: number
+    category: config
+    name: Timer
+    icon: "mdi:timer"
+    dps:
+      - id: 11
+        name: value
+        type: integer
+        unit: min
+        range:
+          min: 0
+          max: 86400
+        mapping:
+          - scale: 60
+            step: 60
+  - entity: sensor
+    name: Work Mode
+    class: enum
+    category: diagnostic
+    dps:
+      - id: 12
+        type: string
+        name: sensor
+        mapping:
+          - dps_val: "manual"
+            value: "Manual"
+          - dps_val: "auto"
+            value: "Auto"
+          - dps_val: "idle"
+            value: "Idle"

--- a/custom_components/tuya_local/devices/Moistenland_WaterTimer.yaml
+++ b/custom_components/tuya_local/devices/Moistenland_WaterTimer.yaml
@@ -2,6 +2,9 @@ name: Moistenland Irrigation
 products:
   - id: 8t5hebn0
     name: MoistenLand Timer
+### Bluetooth Gateway GWB-03 Only handles one connection at a time,
+### even when using Tuya Cloud. Non Persistent connection required.
+    persist: False
 primary_entity:
   entity: switch
   dps:
@@ -87,3 +90,18 @@ secondary_entities:
             value: "Auto"
           - dps_val: "idle"
             value: "Idle"
+### Usage time not updating as expected. DP included but may need to be modified. Not sure what information this DP is actually providing
+  - entity: sensor
+    name: Use_Time_s
+    category: diagnostic
+    dps:
+      - id: 15
+        type: integer
+        name: sensor
+        range:
+          min: 0
+          max: 86400
+        unit: s
+        mapping:
+          - scale: 1
+            step:  1           


### PR DESCRIPTION
Added Device support for moistenland water timer. It appears that there are several versions of this timer out there. (I have three timers. two of which don't report DP:15 and one of which does.)